### PR TITLE
fix: make withAnalytics strictly accept `App`

### DIFF
--- a/src/withAnalytics.tsx
+++ b/src/withAnalytics.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable no-restricted-globals */
 
 import React from 'react';
+import App, { AppProps } from 'next/app';
 import { SingletonRouter } from 'next/router';
 
 import * as debugAnalytics from './helpers/debug';
@@ -34,19 +35,14 @@ export interface WithAnalyticsState {
   analytics?: Partial<AnalyticsHelpers>;
 }
 
-export function withAnalytics<P extends {}>(
-  Router: SingletonRouter,
-  config: WithAnalyticsConfig = {},
-) {
-  return (WrappedComponent: any) => {
-    return class extends React.Component<P & WithAnalyticsState, WithAnalyticsState> {
-      public static displayName = `withAuthSync(${getDisplayName(WrappedComponent)})`;
-
-      public static getInitialProps = WrappedComponent.getInitialProps;
+export function withAnalytics(Router: SingletonRouter, config: WithAnalyticsConfig = {}) {
+  return (WrappedComponent: typeof App) => {
+    return class extends React.Component<AppProps & WithAnalyticsState, WithAnalyticsState> {
+      public static displayName = `withAnalytics(${getDisplayName(WrappedComponent)})`;
 
       public analytics: AnalyticsHelpers | undefined = undefined;
 
-      public constructor(props: P) {
+      public constructor(props: AppProps) {
         super(props);
 
         this.state = {

--- a/test/withAnalytics.test.tsx
+++ b/test/withAnalytics.test.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
 import * as React from 'react';
-import { NextPage } from 'next';
 import { render, cleanup } from '@testing-library/react';
 
 import Router from 'next/router';
@@ -21,8 +20,8 @@ afterEach(cleanup);
 
 describe('withAnalytics', () => {
   test('renders correctly', () => {
-    const TestPage: NextPage = () => <div>Example page</div>;
-    const WithAnalytics = withAnalytics(Router)(TestPage);
+    const TestApp: any = () => <div>h</div>;
+    const WithAnalytics: any = withAnalytics(Router)(TestApp);
     const { container } = render(<WithAnalytics />);
 
     expect(container).toBeInTheDocument();


### PR DESCRIPTION
This HOC is meant to be used in the `_app` page, so typings are restricted for said component only.