### PR TITLE
refactor: app-friendly api

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,0 +1,56 @@
+import { WithAnalyticsConfig, AnalyticsHelpers } from './types';
+
+import * as debugAnalytics from './helpers/debug';
+import * as prodAnalytics from './helpers/prod';
+
+const isLocalhost =
+  typeof window !== 'undefined' &&
+  Boolean(
+    window.location.hostname === 'localhost' ||
+      // [::1] is the IPv6 localhost address.
+      window.location.hostname === '[::1]' ||
+      // 127.0.0.1/8 is considered localhost for IPv4.
+      window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/),
+  );
+
+const isDev = process.env.NODE_ENV !== 'production';
+
+const isDntEnabled =
+  // Do not add Google Analytics when building the static site...
+  typeof window === 'undefined' ||
+  // ...or when DoNotTrack is enabled:
+  (typeof window.navigator !== 'undefined' && window.navigator.doNotTrack === '1');
+
+export interface AnalyticsInstance {
+  analytics?: AnalyticsHelpers;
+  handleRouteChange: () => void;
+}
+
+export function initAnalytics(config: WithAnalyticsConfig = {}): AnalyticsInstance {
+  let analytics: AnalyticsHelpers | undefined;
+
+  if (isDev || isLocalhost) {
+    analytics = debugAnalytics;
+  }
+
+  if (!isDntEnabled || !config.respectDNT) {
+    // Only load analytics if we're sure DNT is not enabled AND respectDNT is enabled
+    analytics = prodAnalytics;
+  }
+
+  if (analytics) {
+    // init analytics
+    analytics.init(config.trackingCode);
+    // log page for first view
+    analytics.pageview();
+  }
+
+  const handleRouteChange = () => {
+    if (analytics) {
+      // log page
+      analytics.pageview();
+    }
+  };
+
+  return { analytics, handleRouteChange };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export * from './analytics';
 export * from './withAnalytics';
 export * from './types';


### PR DESCRIPTION
Detaches analytics initializers into a separate `initAnalytics` function
to accomodate Next.js 9's new Automatic Prerendering feature.

The `withAnalytics` HOC remains available for backwards compatibility
with Next.js 8, but using it on Next.js 9 will disable the Automatic
Prerendering feature, meaning we won't be able to get static pages where
needed.

The `initAnalytics` function will create an analytics instance with any
options passed into it. To use it, create a custom `_app` page with the
`initAnalytics()` called inside it. You can now use the analytics
instance to create a route event listener for tracking pageviews, as
well as passing analytics helper functions into all pages as a prop.